### PR TITLE
Removes the custom viewport if you are not in a GitHub repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
       "explorer": [
         {
           "id": "githubIssuesPrs",
-          "name": "GitHub Issues and PRs"
+          "name": "GitHub Issues and PRs",
+          "when": "is-running-a-github-repo"
         }
       ]
     },

--- a/src/github-issues-prs.ts
+++ b/src/github-issues-prs.ts
@@ -183,6 +183,8 @@ export class GitHubIssuesPrsProvider implements TreeDataProvider<TreeItem> {
 		const remotes = await this.getGitHubRemotes();
 		if (!remotes.length) {
 			return [new TreeItem('No GitHub repositories found')];
+		} else {
+			commands.executeCommand('setContext', 'is-running-a-github-repo', true);
 		}
 
 		let assignee: string | undefined;


### PR DESCRIPTION
This hides the extension viewport by default and then adds the viewport when it's been confirmed that you're in a GitHub repo.